### PR TITLE
Changes to GE converter to address segmentation fault message with ScanArchive conversion

### DIFF
--- a/GE_converter_demo/ge_to_ismrmrd_converter/cmake/FindOrchestra.cmake
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/cmake/FindOrchestra.cmake
@@ -19,12 +19,22 @@ foreach(libs
          Epi
          EpiDiffusion
          EpiMultiPhase
+         EpiReferenceScan
+         EpiDistortionCorrection
          Asset
+         Scic
+         Pure1
+         Pure2
          Arc
          Cartesian2D
+         Cartesian3D
+         BiasCorrection
+         Calibration3D
+         Clariview
          Gradwarp
          Legacy
          Core
+         Flex
          CalibrationCommon
          Foundation
          Acquisition
@@ -37,6 +47,13 @@ foreach(libs
          SystemServicesImplementation
          SystemServicesInterface
          System
+         MoCo
+         SpectroMultiVoxel
+         SpectroMCSI
+         SpectroMCSILegacy
+         SpectroSingleVoxel
+         FrameDownSampler
+         TestSupport
        )
 
     message("Finding library: lib${libs}.a")

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/GERawConverter.cpp
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/GERawConverter.cpp
@@ -1,4 +1,3 @@
-
 /** @file GERawConverter.cpp */
 #include <iostream>
 #include <stdexcept>
@@ -332,11 +331,11 @@ std::vector<ISMRMRD::Acquisition> GERawConverter::getAcquisitions(unsigned int v
 {
    if (rawObjectType_ == SCAN_ARCHIVE_RAW_TYPE)
    {
-      return plugin_->getConverter()->getAcquisitions(scanArchive_.get(), view_num);
+     return plugin_->getConverter()->getAcquisitions(scanArchive_, view_num);
    }
    else
    {
-      return plugin_->getConverter()->getAcquisitions(pfile_.get(), view_num);
+      return plugin_->getConverter()->getAcquisitions(pfile_, view_num);
    }
 }
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/GERawConverter.h
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/GERawConverter.h
@@ -77,9 +77,10 @@ private:
     std::string stylesheet_;
 
     GERecon::Legacy::PfilePointer pfile_;
+
+    GERecon::ScanArchivePointer scanArchive_;
     GERecon::Legacy::LxDownloadDataPointer lxData_;
     GERecon::Control::ProcessingControlPointer processingControl_;
-    GERecon::ScanArchivePointer scanArchive_;
     int rawObjectType_; // to allow reference to a P-File or ScanArchive object
     std::shared_ptr<Plugin> plugin_;
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/GenericConverter.cpp
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/GenericConverter.cpp
@@ -8,7 +8,7 @@
 #include "GenericConverter.h"
 
 struct LOADTEST {
-  LOADTEST()  { std::cerr << __FILE__ << ": shared object loaded" << std::endl; }
+   LOADTEST() { std::cerr << __FILE__ << ": shared object loaded"   << std::endl; }
   ~LOADTEST() { std::cerr << __FILE__ << ": shared object unloaded" << std::endl; }
 } loadTest;
 
@@ -43,7 +43,7 @@ int GenericConverter::get_view_idx(GERecon::Control::ProcessingControlPointer pr
 
 
 
-std::vector<ISMRMRD::Acquisition> GenericConverter::getAcquisitions(GERecon::Legacy::Pfile* pfile,
+std::vector<ISMRMRD::Acquisition> GenericConverter::getAcquisitions(GERecon::Legacy::PfilePointer &pfile,
                                                                     unsigned int acqMode)
 {
     std::vector<ISMRMRD::Acquisition> acqs;
@@ -179,14 +179,13 @@ std::vector<ISMRMRD::Acquisition> GenericConverter::getAcquisitions(GERecon::Leg
 
 
 
-std::vector<ISMRMRD::Acquisition> GenericConverter::getAcquisitions(GERecon::ScanArchive* scanArchive,
+std::vector<ISMRMRD::Acquisition> GenericConverter::getAcquisitions(GERecon::ScanArchivePointer &scanArchivePtr,
                                                                     unsigned int acqMode)
 {
    std::vector<ISMRMRD::Acquisition> acqs;
 
-   GERecon::ScanArchivePointer scanArchivePtr(scanArchive);
    GERecon::Acquisition::ArchiveStoragePointer archiveStoragePointer = GERecon::Acquisition::ArchiveStorage::Create(scanArchivePtr);
-   GERecon::Legacy::LxDownloadDataPointer lxData = boost::dynamic_pointer_cast<GERecon::Legacy::LxDownloadData>(scanArchive->LoadDownloadData());
+   GERecon::Legacy::LxDownloadDataPointer lxData = boost::dynamic_pointer_cast<GERecon::Legacy::LxDownloadData>(scanArchivePtr->LoadDownloadData());
    boost::shared_ptr<GERecon::Legacy::LxControlSource> const controlSource = boost::make_shared<GERecon::Legacy::LxControlSource>(lxData);
    GERecon::Control::ProcessingControlPointer processingControl = controlSource->CreateOrchestraProcessingControl();
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/GenericConverter.h
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/GenericConverter.h
@@ -10,10 +10,10 @@ namespace PfileToIsmrmrd {
 class GenericConverter: public SequenceConverter
 {
 public:
-    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::Legacy::Pfile* pfile,
+    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::Legacy::PfilePointer &pfile,
                                                                unsigned int view_num);
 
-    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::ScanArchive* scanArchive,
+    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::ScanArchivePointer &scanArchivePtr,
                                                                unsigned int view_num);
 
 protected:

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/2dfastNoiseConverter.cpp
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/2dfastNoiseConverter.cpp
@@ -3,7 +3,7 @@
 
 #include "2dfastNoiseConverter.h"
 
-std::vector<ISMRMRD::Acquisition> NIH2dfastNoiseConverter::getAcquisitions(GERecon::Legacy::Pfile* pfile,
+std::vector<ISMRMRD::Acquisition> NIH2dfastNoiseConverter::getAcquisitions(GERecon::Legacy::PfilePointer &pfile,
                                                                            unsigned int acqMode)
 {
     std::vector<ISMRMRD::Acquisition> acqs;
@@ -94,14 +94,13 @@ std::vector<ISMRMRD::Acquisition> NIH2dfastNoiseConverter::getAcquisitions(GERec
 
 
 
-std::vector<ISMRMRD::Acquisition> NIH2dfastNoiseConverter::getAcquisitions(GERecon::ScanArchive* scanArchive,
+std::vector<ISMRMRD::Acquisition> NIH2dfastNoiseConverter::getAcquisitions(GERecon::ScanArchivePointer &scanArchivePtr,
                                                                            unsigned int acqMode)
 {
    std::vector<ISMRMRD::Acquisition> acqs;
 
-   GERecon::ScanArchivePointer scanArchivePtr(scanArchive);
    GERecon::Acquisition::ArchiveStoragePointer archiveStoragePointer = GERecon::Acquisition::ArchiveStorage::Create(scanArchivePtr);
-   GERecon::Legacy::LxDownloadDataPointer lxData = boost::dynamic_pointer_cast<GERecon::Legacy::LxDownloadData>(scanArchive->LoadDownloadData());
+   GERecon::Legacy::LxDownloadDataPointer lxData = boost::dynamic_pointer_cast<GERecon::Legacy::LxDownloadData>(scanArchivePtr->LoadDownloadData());
    boost::shared_ptr<GERecon::Legacy::LxControlSource> const controlSource = boost::make_shared<GERecon::Legacy::LxControlSource>(lxData);
    GERecon::Control::ProcessingControlPointer processingControl = controlSource->CreateOrchestraProcessingControl();
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/2dfastNoiseConverter.h
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/2dfastNoiseConverter.h
@@ -10,10 +10,10 @@
 class NIH2dfastNoiseConverter: public PfileToIsmrmrd::GenericConverter
 {
 public:
-   std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::Legacy::Pfile* pfile,
+   std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::Legacy::PfilePointer &pfile,
                                                      unsigned int acqMode);
 
-   std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::ScanArchive* scanArchive,
+   std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::ScanArchivePointer &scanArchive,
                                                      unsigned int acqMode);
 };
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/epiConverter.cpp
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/epiConverter.cpp
@@ -4,7 +4,7 @@
 #include "epiConverter.h"
 
 
-std::vector<ISMRMRD::Acquisition> NIHepiConverter::getAcquisitions(GERecon::Legacy::Pfile* pfile,
+std::vector<ISMRMRD::Acquisition> NIHepiConverter::getAcquisitions(GERecon::Legacy::PfilePointer &pfile,
                                                                    unsigned int acqMode)
 {
    std::cerr << "Currently, conversion of EPI P-files is __NOT__ supported." << std::endl;
@@ -14,16 +14,15 @@ std::vector<ISMRMRD::Acquisition> NIHepiConverter::getAcquisitions(GERecon::Lega
 
 
 
-std::vector<ISMRMRD::Acquisition> NIHepiConverter::getAcquisitions(GERecon::ScanArchive* scanArchive,
+std::vector<ISMRMRD::Acquisition> NIHepiConverter::getAcquisitions(GERecon::ScanArchivePointer &scanArchivePtr,
                                                                    unsigned int acqMode)
 {
    std::cerr << "Using NIHepi ScanArchive converter." << std::endl;
 
-   GERecon::ScanArchivePointer scanArchivePtr(scanArchive);
    boost::filesystem::path scanArchivePath = scanArchivePtr->Path();
 
    GERecon::Acquisition::ArchiveStoragePointer archiveStoragePointer    = GERecon::Acquisition::ArchiveStorage::Create(scanArchivePtr);
-   GERecon::Legacy::LxDownloadDataPointer lxData                        = boost::dynamic_pointer_cast<GERecon::Legacy::LxDownloadData>(scanArchive->LoadDownloadData());
+   GERecon::Legacy::LxDownloadDataPointer lxData                        = boost::dynamic_pointer_cast<GERecon::Legacy::LxDownloadData>(scanArchivePtr->LoadDownloadData());
    boost::shared_ptr<GERecon::Epi::LxControlSource> const controlSource = boost::make_shared<GERecon::Epi::LxControlSource>(lxData);
    GERecon::Control::ProcessingControlPointer processingControl         = controlSource->CreateOrchestraProcessingControl();
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/epiConverter.h
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/NIHPlugins/epiConverter.h
@@ -23,11 +23,11 @@ class NIHepiConverter: public PfileToIsmrmrd::GenericConverter
 {
 public:
 
-   virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::Legacy::Pfile* pfile,
-                                                               unsigned int view_num);
+   virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::Legacy::PfilePointer &pfile,
+							      unsigned int view_num);
 
-   virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::ScanArchive* scanArchive,
-                                                               unsigned int view_num);
+   virtual std::vector<ISMRMRD::Acquisition> getAcquisitions (GERecon::ScanArchivePointer &scanArchive,
+							      unsigned int view_num);
 
 };
 

--- a/GE_converter_demo/ge_to_ismrmrd_converter/src/SequenceConverter.h
+++ b/GE_converter_demo/ge_to_ismrmrd_converter/src/SequenceConverter.h
@@ -85,10 +85,10 @@ public:
      * Pure virtual function templates
      */
 
-    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::Legacy::Pfile*     pfile,
+    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::Legacy::PfilePointer &pfile,
                                                               unsigned int view_num) = 0;
 
-    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::ScanArchive* scanArchive,
+    virtual std::vector<ISMRMRD::Acquisition> getAcquisitions(GERecon::ScanArchivePointer &scanArchive,
                                                               unsigned int view_num) = 0;
 };
 


### PR DESCRIPTION
These changes address an issue with the GE to ISMRMRD converter that occurred when trying to convert ScanArchive formatted raw data.  Even when the conversion happened successfully, a segmentation fault would be generated.  This issue was addressed in the main converter repository at:

https://github.com/ismrmrd/ge_to_ismrmrd/commit/0dc7784e9a6b13ee4b467fdefcfbdd5774ae984e

Credit to jad11nih for the fix.